### PR TITLE
fix: openai selector

### DIFF
--- a/src/providers/openai.js
+++ b/src/providers/openai.js
@@ -21,7 +21,7 @@ class OpenAI extends Provider {
 
 	static handleSubmit() {
 		this.getWebview().executeJavaScript(`{
-        var btn = document.querySelector('button[data-testid="fruitjuice-send-button"]');
+        var btn = document.querySelector('button[data-testid="send-button"]') || document.querySelector('button[data-testid="fruitjuice-send-button"]');
         if (btn) {
             btn.focus();
             btn.disabled = false;


### PR DESCRIPTION
Switched the test-id selector for chatGPT ui. Using the previous test-id as a fallback since different test-ids seems to be used for different users.