### PR TITLE
feat: regain focus from previous application on quickopen shortcut

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -18,6 +18,7 @@ import {
 	ipcMain,
 	globalShortcut,
 	Event,
+	Menu,
 } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
@@ -363,7 +364,8 @@ function setSuperpromptFocusState(state: boolean) {
 function quickOpen() {
 	if (mainWindow && !mainWindow.isDestroyed()) {
 		if (mainWindow.isFocused()) {
-			mainWindow.hide();
+			Menu.sendActionToFirstResponder('hide:');
+			// mainWindow.hide();
 		} else {
 			if (mainWindow.isMinimized()) {
 				mainWindow.restore();


### PR DESCRIPTION
### UX improvement
Now the previous application that was focused gets focused again when the quickopen shortcut `⌘+⇧+G` is pressed to hide GodMode. No more mouse click necessary. 

Only tested on MacOS