### PR TITLE
Focus superprompt on pane close

### DIFF
--- a/src/components/pane.tsx
+++ b/src/components/pane.tsx
@@ -140,6 +140,7 @@ export default function Pane({
 						.getWebview()
 						// @ts-ignore
 						.setZoomLevel(provider.getWebview().getZoomLevel() - 2);
+					window.electron.mainWindow.focusSuperprompt();
 				}}
 			>
 				<DialogXContent
@@ -155,7 +156,6 @@ export default function Pane({
 									onClick={() => {
 										provider
 											.getWebview()
-											// @ts-ignore
 											.setZoomLevel(provider.getWebview().getZoomLevel() + 1);
 									}}
 								>
@@ -166,7 +166,6 @@ export default function Pane({
 									onClick={() => {
 										provider
 											.getWebview()
-											// @ts-ignore
 											.setZoomLevel(provider.getWebview().getZoomLevel() - 1);
 									}}
 								>
@@ -175,10 +174,7 @@ export default function Pane({
 								<XButton
 									tooltip={`Reset Zoom`} // : ${CmdOrCtrlKey} + 0`}
 									onClick={() => {
-										provider
-											.getWebview()
-											// @ts-ignore
-											.setZoomLevel(0);
+										provider.getWebview().setZoomLevel(0);
 									}}
 								>
 									<MagnifyingGlassIcon />

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,7 +5,7 @@ export interface ProviderInterface {
 	fullName: string;
 	shortName: string;
 	webviewId: string;
-	getWebview(): HTMLElement | null;
+	getWebview(): Electron.WebviewTag;
 	url: string;
 	paneId(): string;
 	setupCustomPasteBehavior(): void;
@@ -27,8 +27,8 @@ export interface ProviderInterface {
 export interface Settings {
 	getGlobalShortcut: () => Promise<string>;
 	setGlobalShortcut: (shortcut: string) => Promise<boolean>;
-	getFocusSuperprompt: () => Promise<boolean>;
-	setFocusSuperprompt: (state: boolean) => Promise<boolean>;
+	getFocusSuperpromptSetting: () => Promise<boolean>;
+	setFocusSuperpromptSetting: (state: boolean) => Promise<boolean>;
 	getPlatform: () => Promise<string>;
 }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -69,6 +69,11 @@ ipcMain.on('get-always-on-top', async (event, property, val) => {
 	const bool = mainWindow?.isAlwaysOnTop();
 	event.returnValue = bool;
 });
+ipcMain.on('focus-superprompt', async (event, property, val) => {
+	mainWindow?.webContents.executeJavaScript(
+		`{document.querySelector('#prompt')?.focus()}`,
+	);
+});
 
 const appFolder = path.dirname(process.execPath);
 const updateExe = path.resolve(appFolder, '..', 'Update.exe');
@@ -399,11 +404,11 @@ ipcMain.handle('set-global-shortcut', async (event, shortcut: string) => {
 	return true;
 });
 
-ipcMain.handle('get-focus-superprompt', () => {
+ipcMain.handle('get-focus-superprompt-setting', () => {
 	return store.get('focusSuperpromptEnabled', false);
 });
 
-ipcMain.handle('set-focus-superprompt', async (_, state: boolean) => {
+ipcMain.handle('set-focus-superprompt-setting', async (_, state: boolean) => {
 	setSuperpromptFocusState(state);
 	return true;
 });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -54,6 +54,11 @@ const electronHandler = {
 			ipcRenderer.send('disable-open-at-login');
 		},
 	},
+	mainWindow: {
+		focusSuperprompt() {
+			ipcRenderer.send('focus-superprompt');
+		},
+	},
 };
 
 contextBridge.exposeInMainWorld('electron', electronHandler);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -65,11 +65,11 @@ contextBridge.exposeInMainWorld('settings', {
 	setGlobalShortcut: (shortcut: string) => {
 		return ipcRenderer.invoke('set-global-shortcut', shortcut);
 	},
-	getFocusSuperprompt: () => {
-		return ipcRenderer.invoke('get-focus-superprompt');
+	getFocusSuperpromptSetting: () => {
+		return ipcRenderer.invoke('get-focus-superprompt-setting');
 	},
-	setFocusSuperprompt: (state: boolean) => {
-		return ipcRenderer.invoke('set-focus-superprompt', state);
+	setFocusSuperpromptSetting: (state: boolean) => {
+		return ipcRenderer.invoke('set-focus-superprompt-setting', state);
 	},
 	getPlatform: () => {
 		return ipcRenderer.invoke('get-platform');

--- a/src/renderer/components/settings.tsx
+++ b/src/renderer/components/settings.tsx
@@ -90,7 +90,7 @@ export default function SettingsMenu({
 			setShortcut(initialShortcut?.split('+'));
 		};
 		const setInitialSuperpromptFocus = async () => {
-			const initialState = await settings.getFocusSuperprompt();
+			const initialState = await settings.getFocusSuperpromptSetting();
 			setSuperpromptFocus(initialState);
 		};
 		displayShortcut();
@@ -110,7 +110,7 @@ export default function SettingsMenu({
 	// Toggle superprompt focus setting in electron store
 	useEffect(() => {
 		const updateSuperpromptFocus = async () => {
-			await settings.setFocusSuperprompt(superpromptFocus);
+			await settings.setFocusSuperpromptSetting(superpromptFocus);
 		};
 		updateSuperpromptFocus();
 	}, [superpromptFocus]);

--- a/src/renderer/layout.tsx
+++ b/src/renderer/layout.tsx
@@ -200,7 +200,7 @@ export default function Layout() {
 	}
 
 	return (
-		<div id="windowRef" className="flex flex-col">
+		<div className="flex flex-col">
 			<TitleBar {...{ isAlwaysOnTop, toggleIsAlwaysOnTop }} />
 			<SettingsMenu
 				open={isSettingsOpen}

--- a/src/renderer/layout.tsx
+++ b/src/renderer/layout.tsx
@@ -78,7 +78,6 @@ export default function Layout() {
 		});
 	}, [enabledProviders, superprompt]);
 
-	const formRef = React.useRef<HTMLDivElement>(null); // don't actually use a <form> because it will just reload on submit even if you preventdefault
 	const SuperPromptEnterKey = window.electron.electronStore.get(
 		'SuperPromptEnterKey',
 		false,
@@ -100,11 +99,7 @@ export default function Layout() {
 		}
 	}
 
-	const windowRef = React.useRef<HTMLDivElement>(null);
-
 	function updateSplitSizes(panes: any[], focalIndex: number | null = null) {
-		// const clientWidth = windowRef.current?.clientWidth!;
-		// const remainingWidth = ((clientWidth - 100) / clientWidth) * 100;
 		const remainingWidth = 100;
 		// Handle specific pane focus
 		if (focalIndex !== null || focalIndex === 'A') {
@@ -205,7 +200,7 @@ export default function Layout() {
 	}
 
 	return (
-		<div id="windowRef" className="flex flex-col" ref={windowRef}>
+		<div id="windowRef" className="flex flex-col">
 			<TitleBar {...{ isAlwaysOnTop, toggleIsAlwaysOnTop }} />
 			<SettingsMenu
 				open={isSettingsOpen}
@@ -235,7 +230,6 @@ export default function Layout() {
 			</Split>
 			<div
 				// not a form, because the form submit causes a reload for some reason even if we preventdefault.
-				ref={formRef}
 				id="form"
 				className=""
 				// onKeyDown={handleSubmit}


### PR DESCRIPTION
Whenever the <Pane /> view would get closed users would have to manually click the prompt textarea again to be able to write another prompt. Now that textarea gets focused automatically whenever the pane closes.