### PR TITLE
Add Mistral provider

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -21,7 +21,7 @@ import Falcon180BSpace from 'providers/falcon180bspace';
 import Grok from 'providers/grok';
 import Deepseek from 'providers/deepseek';
 import AIStudio from 'providers/aistudio';
-
+import Mistral from 'providers/mistral';
 export const allProviders = [
 	OpenAi,
 	Grok,
@@ -33,6 +33,7 @@ export const allProviders = [
 	Deepseek,
 	YouChat,
 	Perplexity,
+	Mistral,
 	Phind,
 	Poe,
 	InflectionPi,

--- a/src/providers/mistral.js
+++ b/src/providers/mistral.js
@@ -37,6 +37,12 @@ class Mistral extends Provider {
 	static handleSubmit() {
 		this.getWebview().executeJavaScript(`
             try {
+                const inputElement = document.querySelector("body > main textarea");
+		let tempValue = inputElement.value;
+		inputElement.value = "";
+                inputElement.setRangeText(tempValue); // submit button doesn't work without this.
+                inputElement.dispatchEvent(new Event('input', { bubbles: true }));
+
                 const submitButton = document.querySelector('button[aria-label^="Send"]');
                 if (!submitButton) {
                     throw new Error('Submit button not found');

--- a/src/providers/mistral.js
+++ b/src/providers/mistral.js
@@ -1,0 +1,64 @@
+const Provider = require('./provider');
+
+/**
+ * @class Mistral
+ * @extends Provider
+ * @description Provider class for Mistral AI chat interface integration
+ */
+class Mistral extends Provider {
+	static webviewId = 'webviewMistral';
+	static fullName = 'Mistral';
+	static shortName = 'Mistral';
+
+	static url = 'https://chat.mistral.ai/';
+
+	/**
+	 * @param {string} input - The text input to be sent to Mistral
+	 * @throws {Error} If the input element cannot be found
+	 */
+	static handleInput(input) {
+		this.getWebview().executeJavaScript(`
+            try {
+                const inputElement = document.querySelector("body > main textarea");
+                if (!inputElement) {
+                    throw new Error('Input element not found');
+                }
+                inputElement.value = \`${input}\`;
+                inputElement.dispatchEvent(new Event('input', { bubbles: true }));
+            } catch (error) {
+                console.error('Error in Mistral handleInput:', error);
+            }
+        `);
+	}
+
+	/**
+	 * Triggers the submit action for the chat input
+	 */
+	static handleSubmit() {
+		this.getWebview().executeJavaScript(`
+            try {
+                const submitButton = document.querySelector('button[aria-label^="Send"]');
+                if (!submitButton) {
+                    throw new Error('Submit button not found');
+                }
+                submitButton.click();
+            } catch (error) {
+                console.error('Error in Mistral handleSubmit:', error);
+            }
+        `);
+	}
+
+	/**
+	 * Applies custom CSS styling to the Mistral chat interface
+	 */
+	static handleCss() {}
+
+	/**
+	 * @returns {boolean} Whether the Mistral provider is enabled
+	 */
+	static isEnabled() {
+		return window.electron?.electronStore?.get(`${this.webviewId}Enabled`, true) ?? false;
+	}
+}
+
+module.exports = Mistral;


### PR DESCRIPTION
This pull request introduces a new provider, [Mistral](https://chat.mistral.ai/), to the application. 

![image](https://github.com/user-attachments/assets/1a579d0a-81cb-4f36-a0f2-3469085a5e20)


Key changes:

### New Provider Integration:

* [`src/lib/constants.ts`](diffhunk://#diff-8c943ccfb5928fff63708e99eaafa93f8845c9405ed8e4b32afed23e5003025aL24-R24): Imported the `Mistral` provider and added it to the `allProviders` array. [[1]](diffhunk://#diff-8c943ccfb5928fff63708e99eaafa93f8845c9405ed8e4b32afed23e5003025aL24-R24) [[2]](diffhunk://#diff-8c943ccfb5928fff63708e99eaafa93f8845c9405ed8e4b32afed23e5003025aR36)
* [`src/providers/mistral.js`](diffhunk://#diff-885201d8b7e6c43832f1441982a1011e91fa6b2851966d9a2565937c92980701R1-R64): Created a new `Mistral` class extending the `Provider` class, which includes methods for handling input, submitting actions, applying custom CSS, and checking if the provider is enabled.