### PR TITLE
Refocus superprompt after cmd+shift+a shortcut

### DIFF
--- a/src/renderer/layout.tsx
+++ b/src/renderer/layout.tsx
@@ -149,6 +149,7 @@ export default function Layout() {
 			}
 		} else if (isCmdOrCtrl && isShift && event.key.toLowerCase() === 'a') {
 			window.electron.browserWindow.reload();
+			window.electron.mainWindow.focusSuperprompt();
 		} else if (
 			(isCmdOrCtrl && event.key === '+') ||
 			(isCmdOrCtrl && event.key === '=')


### PR DESCRIPTION
Was annoying having to click the textarea again after cmd+shift+a shortcut...