### PR TITLE
feat(setting): add user-configurable zoom level for preview panes

### DIFF
--- a/src/components/pane.tsx
+++ b/src/components/pane.tsx
@@ -77,12 +77,10 @@ export default function Pane({
 			<div className="hidden powerbar group-hover:block">
 				<Button
 					className="text-xs shadow-2xl"
-					onClick={() => {
+					onClick={async () => {
 						setOpenPreviewPane(number);
 						console.log('zooming in on ', provider);
-						// @ts-ignore
-						const zoomLevel = provider?.getWebview()?.getZoomLevel() + 2;
-						// @ts-ignore
+						const zoomLevel = await window.settings.getZoomSetting();
 						provider.getWebview()?.setZoomLevel(zoomLevel);
 					}}
 					variant="ghost"
@@ -109,10 +107,13 @@ export default function Pane({
 				onOpenChange={() => {
 					setOpenPreviewPane(0);
 					// zoom out when dropping out of preview
-					provider
-						.getWebview()
-						// @ts-ignore
-						.setZoomLevel(provider.getWebview().getZoomLevel() - 2);
+					const resetZoom = async () => {
+						const zoomSetting = await window.settings.getZoomSetting();
+						provider
+							.getWebview()
+							.setZoomLevel(provider.getWebview().getZoomLevel() - zoomSetting);
+					};
+					resetZoom();
 					window.electron.mainWindow.focusSuperprompt();
 				}}
 			>

--- a/src/components/pane.tsx
+++ b/src/components/pane.tsx
@@ -51,33 +51,6 @@ export default function Pane({
 		return () => clearInterval(interval);
 	});
 
-	// this did not work not sure why
-	// // set a timer effect every second to check if the webview is can go back
-	// const [canGoBack, setCanGoBack] = React.useState(false);
-	// const [canGoFwd, setCanGoFwd] = React.useState(false);
-	// React.useEffect(() => {
-	// 	const interval = setInterval(() => {
-	// 		console.log(
-	// 			'provider.getWebview()?.canGoBack()',
-	// 			provider.getWebview(),
-	// 			provider.getWebview()?.canGoBack()
-	// 		);
-	// 		// @ts-ignore
-	// 		if (provider.getWebview()?.canGoBack()) {
-	// 			setCanGoBack(true);
-	// 		} else {
-	// 			setCanGoBack(false);
-	// 		}
-	// 		// @ts-ignore
-	// 		if (provider.getWebview()?.canGoForward()) {
-	// 			setCanGoFwd(true);
-	// 		} else {
-	// 			setCanGoFwd(true);
-	// 		}
-	// 	}, 1000);
-	// 	return () => clearInterval(interval);
-	// });
-
 	function XButton({ children, tooltip, onClick, className = '' }: any) {
 		return (
 			<TooltipProvider delayDuration={300}>
@@ -197,7 +170,7 @@ export default function Pane({
 									<ReloadIcon />
 								</XButton>
 								<XButton
-									tooltip={`Go Back`} // : ${CmdOrCtrlKey} + H`}
+									tooltip={`Go Back`}
 									onClick={() => {
 										provider.getWebview()?.goBack();
 									}}
@@ -205,7 +178,7 @@ export default function Pane({
 									<ArrowLeftIcon />
 								</XButton>
 								<XButton
-									tooltip={`Go forward`} // : ${CmdOrCtrlKey} + L`}
+									tooltip={`Go forward`}
 									onClick={() => {
 										provider.getWebview()?.goForward();
 									}}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,6 +29,8 @@ export interface Settings {
 	setGlobalShortcut: (shortcut: string) => Promise<boolean>;
 	getFocusSuperpromptSetting: () => Promise<boolean>;
 	setFocusSuperpromptSetting: (state: boolean) => Promise<boolean>;
+	getZoomSetting: () => Promise<number>;
+	setZoomSetting: (level: number) => Promise<boolean>;
 	getPlatform: () => Promise<string>;
 }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -111,6 +111,16 @@ ipcMain.handle('get-open-at-login', () => {
 	return openAtLogin;
 });
 
+ipcMain.handle('get-zoom-setting', () => {
+	return store.get('zoomSetting', 2);
+});
+
+ipcMain.handle('set-zoom-setting', async (_, level: number) => {
+	if (typeof level !== 'number' || level < 0 || level > 6) return false;
+	store.set('zoomSetting', level);
+	return true;
+});
+
 ipcMain.on('prompt-hidden-chat', async (event, channel: string, prompt) => {
 	const sendFn = (...args: any[]) =>
 		mainWindow?.webContents.send(channel, ...args);
@@ -422,6 +432,11 @@ app.on('ready', () => {
 		globalShortcut.register(quickOpenDefaultShortcut, quickOpen);
 	}
 	store.set('focusSuperpromptEnabled', focusSuperpromptDefault);
+
+	// Initialize zoom level if not set
+	if (!store.has('zoomSetting')) {
+		store.set('zoomSetting', 2);
+	}
 
 	/*
 	 * Re-register global shortcut when it is changed in settings

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -82,6 +82,12 @@ contextBridge.exposeInMainWorld('settings', {
 	getOpenAtLogin: () => {
 		return ipcRenderer.invoke('get-open-at-login');
 	},
+	getZoomSetting: () => {
+		return ipcRenderer.invoke('get-zoom-setting');
+	},
+	setZoomSetting: (level: number) => {
+		return ipcRenderer.invoke('set-zoom-setting', level);
+	},
 });
 
 export type ElectronHandler = typeof electronHandler;

--- a/src/providers/perplexity.js
+++ b/src/providers/perplexity.js
@@ -32,31 +32,7 @@ class Perplexity extends Provider {
       }`);
 	}
 
-	static handleCss() {
-		this.getWebview().addEventListener('dom-ready', () => {
-			// hide message below text input, sidebar, suggestions on new chat
-			setTimeout(() => {
-				this.getWebview().executeJavaScript(`
-
-
-          `);
-			}, 100);
-			// Hide the "Try asking" segment
-			setTimeout(() => {
-				this.getWebview().insertCSS(`
-        body {
-					zoom: 80%;
-					font-size: small;
-        }
-
-        .mt-lg {
-          display: none;
-        }
-		    `);
-			}, 100);
-		});
-		// this.getWebview().setZoomLevel(this.getWebview().getZoomLevel() - 2);
-	}
+	static handleCss() {}
 
 	static getUserAgent() {
 		'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36';

--- a/src/renderer/components/settings.tsx
+++ b/src/renderer/components/settings.tsx
@@ -10,6 +10,7 @@ import {
 	isValidShortcut,
 	type ShortcutKey,
 } from 'lib/utils';
+import { Input } from './ui/input';
 
 export default function SettingsMenu({
 	open,
@@ -24,6 +25,7 @@ export default function SettingsMenu({
 	const [metaKey, setMetaKey] = useState('');
 	const [openAtLogin, setOpenAtLogin] = useState(false);
 	const [superpromptFocus, setSuperpromptFocus] = useState(false);
+	const [zoomSetting, setZoomSetting] = useState(2);
 
 	function classNames(...classes) {
 		return classes.filter(Boolean).join(' ');
@@ -150,6 +152,21 @@ export default function SettingsMenu({
 			: window.electron.browserWindow.disableOpenAtLogin();
 	}, [openAtLogin]);
 
+	useEffect(() => {
+		const fetchZoomSetting = async () => {
+			const level = await settings.getZoomSetting();
+			setZoomSetting(level);
+		};
+		fetchZoomSetting();
+	}, []);
+
+	useEffect(() => {
+		const updateZoomSetting = async () => {
+			await settings.setZoomSetting(zoomSetting);
+		};
+		updateZoomSetting();
+	}, [zoomSetting]);
+
 	return (
 		<Dialog open={open} onOpenChange={onClose}>
 			<DialogContent className="bg-white">
@@ -190,7 +207,7 @@ export default function SettingsMenu({
 							className="text-sm font-medium leading-6 text-gray-900"
 							passive
 						>
-							Focus superprompt input on quick open shortcut
+							Focus Superprompt on Quick Open Shortcut
 						</Switch.Label>
 					</span>
 					<Switch
@@ -210,6 +227,25 @@ export default function SettingsMenu({
 						/>
 					</Switch>
 				</Switch.Group>
+				<div className="flex items-center justify-between py-4">
+					<span className="text-sm font-medium leading-6 text-gray-900">
+						Preview Zoom Level
+					</span>
+					<Input
+						type="number"
+						min={0}
+						max={6}
+						step={0.5}
+						value={zoomSetting}
+						onChange={(e) => {
+							const value = +parseFloat(e.target.value).toFixed(2);
+							if (!isNaN(value) && value >= 0 && value <= 6) {
+								setZoomSetting(value);
+							}
+						}}
+						className="w-20 text-center"
+					/>
+				</div>
 				<span className="flex flex-col flex-grow">
 					<div
 						as="span"

--- a/src/renderer/layout.tsx
+++ b/src/renderer/layout.tsx
@@ -246,7 +246,7 @@ export default function Layout() {
 						name="prompt"
 						placeholder={`Enter a superprompt here.
 - Quick Open: ${CmdOrCtrlKey}+Shift+G or Submit: ${CmdOrCtrlKey}+Enter
-- Switch windows: ${CmdOrCtrlKey}+1/2/3/etc, or Global Resize/Pin: ${CmdOrCtrlKey} -/+/p, or Back/Fwd: ${CmdOrCtrlKey} H/L
+- Switch windows: ${CmdOrCtrlKey}+1/2/3/etc, or Global Resize/Pin: ${CmdOrCtrlKey} -/+/p
 - New chat: ${CmdOrCtrlKey}+R or Reset windows evenly: ${CmdOrCtrlKey}+Shift+A`}
 					/>
 					<div className="flex items-center justify-center p-4 space-x-2">

--- a/src/renderer/layout.tsx
+++ b/src/renderer/layout.tsx
@@ -123,7 +123,7 @@ export default function Layout() {
 
 	const [currentlyOpenPreviewPane, setOpenPreviewPane] = React.useState(0);
 
-	function onKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+	async function onKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
 		const isCmdOrCtrl = event.metaKey || event.ctrlKey;
 		const isShift = event.shiftKey;
 		console.debug('keydown', event.key, isCmdOrCtrl, event);
@@ -142,10 +142,12 @@ export default function Layout() {
 					(provider) =>
 						provider.webviewId === storedPaneList[digit - 1].webviewId,
 				);
+				const zoomSetting =
+					// @ts-ignore
+					previewProvider.getWebview()?.getZoomLevel() +
+					(await window.settings.getZoomSetting());
 				// @ts-ignore
-				const zoomLevel = previewProvider.getWebview()?.getZoomLevel() + 2;
-				// @ts-ignore
-				previewProvider.getWebview().setZoomLevel(zoomLevel);
+				previewProvider.getWebview().setZoomLevel(zoomSetting);
 			}
 		} else if (isCmdOrCtrl && isShift && event.key.toLowerCase() === 'a') {
 			window.electron.browserWindow.reload();


### PR DESCRIPTION
Previously, preview pane zoom was hardcoded to +2. This change gives users control over their preferred zoom level.

- Added zoom level setting for preview panes
- Zoom level can be set between 0-6 with 0.5 step increments
- Saves zoom settings between app uses
- Added UI controls in settings dialog for zoom configuration
- Removed mention of unimplemented shortcuts in superprompt textarea


